### PR TITLE
Fix-lists.

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -60,10 +60,9 @@ export const getTSDataTypeFromFieldType = (field: PrismaDMMF.Field) => {
     case 'Json':
       type = 'Prisma.JsonValue';
       break;
-    default:
-      if (field.isList) {
-        type = `${field.type}[]`;
-      }
+  }
+  if (field.isList) {
+      type = `${type}[]`;
   }
   return type;
 };


### PR DESCRIPTION
### Description

Problem fixed with this MR:

I have a field with the type `Int[]`. The output field, before this MR, would only output `number`, without parsing it as a list. This is now fixed by always running the `field.isList` check.