### PR TITLE
Add support for Bytes/Buffer type

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -60,6 +60,9 @@ export const getTSDataTypeFromFieldType = (field: PrismaDMMF.Field) => {
     case 'Json':
       type = 'Prisma.JsonValue';
       break;
+    case 'Bytes':
+      type = 'Buffer';
+      break;
     default:
       if (field.isList) {
         type = `${field.type}[]`;


### PR DESCRIPTION
The current version does not support correctly generating binary data types (Bytes).

Attempting to add a Bytes data type into the schema.prisma and then run npx prisma generate results in errors in the generated classes that have Bytes.

I added a 'Bytes' to 'Buffer' case in the getTSDataTypeFromFieldType() function in helpers.js, and this resolved the error correctly.

No import needed since Buffer is a globally supported type.