### PR TITLE
Fix/swagger decorator relation type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-class-validator-generator",
-  "version": "5.0.0",
+  "version": "6.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-class-validator-generator",
-      "version": "5.0.0",
+      "version": "6.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^6.12.0",
@@ -24,7 +24,6 @@
       "devDependencies": {
         "@types/node": "^24.0.15",
         "@types/pluralize": "0.0.33",
-        "@types/prettier": "^3.0.0",
         "@vitest/coverage-v8": "^3.2.4",
         "prisma": "^6.12.0",
         "typescript": "^5.8.3",
@@ -1186,17 +1185,6 @@
       "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.33.tgz",
       "integrity": "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==",
       "dev": true
-    },
-    "node_modules/@types/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==",
-      "deprecated": "This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier": "*"
-      }
     },
     "node_modules/@types/validator": {
       "version": "13.15.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-class-validator-generator",
-  "version": "6.0.0-beta.2",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-class-validator-generator",
-      "version": "6.0.0-beta.2",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^6.12.0",
@@ -24,6 +24,7 @@
       "devDependencies": {
         "@types/node": "^24.0.15",
         "@types/pluralize": "0.0.33",
+        "@types/prettier": "^3.0.0",
         "@vitest/coverage-v8": "^3.2.4",
         "prisma": "^6.12.0",
         "typescript": "^5.8.3",
@@ -1185,6 +1186,17 @@
       "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.33.tgz",
       "integrity": "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==",
       "dev": true
+    },
+    "node_modules/@types/prettier": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==",
+      "deprecated": "This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier": "*"
+      }
     },
     "node_modules/@types/validator": {
       "version": "13.15.2",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -200,6 +200,10 @@ export const getSwaggerDecoratorByFieldType = (field: PrismaDMMF.Field) => {
     args.push(`enum: Object.values(${field.type})`);
   }
 
+  if (field.relationName) {
+    args.push(`type: () => ${field.type}`);
+  }
+
   return {
     name: 'ApiProperty',
     arguments: args.length > 0 ? [`{ ${args.join(', ')} }`] : [],

--- a/tests/relation-splitting.test.ts
+++ b/tests/relation-splitting.test.ts
@@ -80,7 +80,7 @@ describe('Relation Splitting Generation', () => {
     expect(userRelations).toContain('import { Post } from "./"');
 
     // Should have decorators for relations
-    expect(userRelations).toContain('@ApiProperty({ isArray: true })');
+    expect(userRelations).toContain('@ApiProperty({ isArray: true, type: () => Post })');
   });
 
   it('should generate combined User class extending base', () => {

--- a/tests/relation-splitting.test.ts
+++ b/tests/relation-splitting.test.ts
@@ -80,7 +80,9 @@ describe('Relation Splitting Generation', () => {
     expect(userRelations).toContain('import { Post } from "./"');
 
     // Should have decorators for relations
-    expect(userRelations).toContain('@ApiProperty({ isArray: true, type: () => Post })');
+    expect(userRelations).toContain(
+      '@ApiProperty({ isArray: true, type: () => Post })',
+    );
   });
 
   it('should generate combined User class extending base', () => {

--- a/tests/swagger-generation.test.ts
+++ b/tests/swagger-generation.test.ts
@@ -32,6 +32,7 @@ describe('Swagger Generation', () => {
     expect(userModel).toContain('type: "string"');
     expect(userModel).toContain('required: false');
     expect(userModel).toContain('isArray: true');
+    expect(userModel).toContain('type: () => Post');
   });
 
   it('should generate Post model with correct Swagger decorators', () => {


### PR DESCRIPTION
### Description

Currently the `@ApiProperty` decorator for the swagger implementation does not include type definition for the relation property type, which results to appear as an empty object within the swagger UI schema description.

This pull request adds the type definition for the relation property type.
